### PR TITLE
Disable 'Delete Workflow Definition' when creating workflow def and disable textbox after it's created

### DIFF
--- a/src/containers/WorkflowDefinitionDetail/index.tsx
+++ b/src/containers/WorkflowDefinitionDetail/index.tsx
@@ -218,7 +218,16 @@ class TransactionTable extends React.Component<IProps, IState> {
           <Button type="primary" onClick={this.saveWorkflowDefinition}>
             Save Workflow Definition
           </Button>
-          <Button type="danger" onClick={this.deleteWorkflowDefinition}>
+          <Button 
+            type="danger" 
+            onClick={this.deleteWorkflowDefinition}
+            disabled = {
+              (
+                this.props.location.pathname === "/definition/workflow/create" &&
+                this.state.saveCount === 0
+              )
+            }
+          >
             Delete Workflow Definition
           </Button>
         </ButtonContainer>

--- a/src/containers/WorkflowDefinitionDetail/index.tsx
+++ b/src/containers/WorkflowDefinitionDetail/index.tsx
@@ -240,8 +240,10 @@ class TransactionTable extends React.Component<IProps, IState> {
               <Form.Item label="Name">
                 <Input
                   disabled={
-                    this.props.location.pathname !==
-                    "/definition/workflow/create"
+                    (
+                      this.props.location.pathname !== "/definition/workflow/create" ||
+                      this.state.saveCount !== 0
+                    )
                   }
                   placeholder="The name of workflow"
                   value={R.path(["name"], workflowDefinition) as any}
@@ -253,8 +255,10 @@ class TransactionTable extends React.Component<IProps, IState> {
               <Form.Item label="Rev">
                 <Input
                   disabled={
-                    this.props.location.pathname !==
-                    "/definition/workflow/create"
+                    (
+                      this.props.location.pathname !== "/definition/workflow/create" ||
+                      this.state.saveCount !== 0
+                    )
                   }
                   placeholder="The revision of workflow"
                   value={R.path(["rev"], workflowDefinition) as any}


### PR DESCRIPTION
Added disabled attribute to 'Delete Workflow Definition'  to check if this endpoint was /workflow/create and saveCount is 0, It's should disable the button

In workflow create screen when user once save the workflow 'Name' and 'Rev' should unable to edit