### PR TITLE
Added DynamicTask & Update melonade-declaration dependency to 0.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1482,9 +1482,9 @@
       }
     },
     "@melonade/melonade-declaration": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@melonade/melonade-declaration/-/melonade-declaration-0.18.1.tgz",
-      "integrity": "sha512-ZkHsn+glhHmGTLt8zv+sNQpXgiEaRkDVsw34lQLK4GTVtVV9DcPPl7dIE1Fl8DhCSUv+4vm43Mx/dVdLPI8ntw==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@melonade/melonade-declaration/-/melonade-declaration-0.18.3.tgz",
+      "integrity": "sha512-IF2c8teJRCMJJDVbHIuyoo77neAG0zWbKSfE3fIQstUyDZqA2yfBUIpxJNukQSt28xLpm/XK0Oj4sRDwVt3c7g==",
       "requires": {
         "ajv": "^6.12.0",
         "ramda": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@antv/data-set": "^0.10.2",
     "@babel/core": "7.6.0",
-    "@melonade/melonade-declaration": "^0.18.1",
+    "@melonade/melonade-declaration": "^0.18.3",
     "@svgr/webpack": "4.3.2",
     "@types/antd": "^1.0.0",
     "@types/axios": "^0.14.0",

--- a/src/components/WorkflowChart/modal.tsx
+++ b/src/components/WorkflowChart/modal.tsx
@@ -85,6 +85,7 @@ export class CreateTaskModal extends React.Component<
               <Option value={Task.TaskTypes.SubTransaction}>
                 Sub-transaction
               </Option>
+              <Option value={Task.TaskTypes.DynamicTask}>Dynamic Task</Option>
             </Select>
           </Form.Item>
           <Form.Item label="Task ReferenceName">
@@ -307,6 +308,30 @@ export class CreateTaskModal extends React.Component<
                 }}
               />
             </React.Fragment>
+          )}
+          {R.pathEq(
+            ["task", "type"],
+            Task.TaskTypes.DynamicTask,
+            this.state
+          ) && (
+            <Form.Item label="Task list">
+              <Input
+                // eslint-disable-next-line no-template-curly-in-string
+                placeholder="list of task to create  (Array of Task e.g. ${workflow.input.tasks})"
+                value={
+                  R.path(
+                    ["inputParameters", "tasks"],
+                    this.state.task
+                  ) as string
+                }
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                  this.onInputChanged(
+                    ["inputParameters", "tasks"],
+                    event.target.value
+                  );
+                }}
+              />
+            </Form.Item>
           )}
         </Form>
       </StyledModal>

--- a/src/components/WorkflowChart/tasks.tsx
+++ b/src/components/WorkflowChart/tasks.tsx
@@ -559,6 +559,22 @@ const SubTransactionModel = (props: ISubTransactionProps) => (
   </SubTransactionModelContainer>
 );
 
+interface IDynamicTaskProps extends IActionButtonProps, ITaskDataProps {
+  task: WorkflowDefinition.IDynamicTask;
+}
+
+const DynamicTaskModel = (props: IDynamicTaskProps) => (
+  <SystemTaskModelContainer
+    backgroundColor={getBackgroundTasksData(
+      props.task.taskReferenceName,
+      props.tasksData
+    )}
+  >
+    <Text>{props.task.taskReferenceName}</Text>
+    <Text code>DYNAMIC</Text>
+  </SystemTaskModelContainer>
+);
+
 interface IAllTaskProps extends IActionButtonProps, ITaskDataProps {
   task: WorkflowDefinition.AllTaskType;
 }
@@ -610,6 +626,16 @@ const AllTaskModel = (props: IAllTaskProps) => {
     case Task.TaskTypes.SubTransaction:
       return (
         <SubTransactionModel
+          task={task}
+          path={props.path}
+          editing={props.editing}
+          onTaskUpdate={props.onTaskUpdate}
+          tasksData={props.tasksData}
+        />
+      );
+    case Task.TaskTypes.DynamicTask:
+      return (
+        <DynamicTaskModel
           task={task}
           path={props.path}
           editing={props.editing}
@@ -694,6 +720,13 @@ const pickTaskProperties = (
         inputParameters: task.inputParameters || {},
         type: task.type,
       } as WorkflowDefinition.IParallelTask;
+    case Task.TaskTypes.DynamicTask:
+      return {
+        taskReferenceName: task.taskReferenceName,
+        dynamicTasks: [],
+        inputParameters: task.inputParameters || {},
+        type: task.type,
+      } as WorkflowDefinition.IDynamicTask;
     default:
       return task;
   }


### PR DESCRIPTION
Add Dynamic Task feature
    - Added Dynamic task option to the workflow definition

Parameters
    - User have to specific task list array for Dynamic Tasks (eg. ${workflow.input.runTasks} or ${task1.output.nextTasks})
![01](https://user-images.githubusercontent.com/4736312/83000650-d6295d00-a034-11ea-8d13-9e77357397bf.png)
![02](https://user-images.githubusercontent.com/4736312/83000665-d9244d80-a034-11ea-8bb6-42e5ea25c4c3.png)

